### PR TITLE
Accept Long Keys for Symmetric Crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Version 2.2.0 (2016-08-22)
+
+* Added an `export()` method to `KeyFactory`, and congruent `import*()`
+  methods. For example:
+  * `export($key)` returns a `string` with a versioned and
+     checksummed, hex-encoded string representing the key material.
+  * `importEncryptionKey($string)` expects an `EncryptionKey`
+     object or throws a `TypeError`
+
 ## Version 2.1.3 (2016-07-29)
 
 * Workaround namespace issue caused by Suhosin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 2.1.3 (2016-07-29)
+
+* Workaround namespace issue caused by Suhosin.
+
 ## Version 2.1.2 (2016-07-11)
 
 * Better docblocks, added unit test to prevent regressions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Halite
 
-[![Build Status](https://travis-ci.org/paragonie/halite.svg?branch=master)](https://travis-ci.org/paragonie/halite)
+[![Build Status](https://travis-ci.org/paragonie/halite.svg?branch=v2.1)](https://travis-ci.org/paragonie/halite)
+[![Latest Stable Version](https://poser.pugx.org/paragonie/halite/v/stable)](https://packagist.org/packages/paragonie/halite)
+[![Latest Unstable Version](https://poser.pugx.org/paragonie/halite/v/unstable)](https://packagist.org/packages/paragonie/halite)
+[![License](https://poser.pugx.org/paragonie/halite/license)](https://packagist.org/packages/paragonie/halite)
+
+> **Note**: This is the version 2 branch.
 
 Halite is a high-level cryptography interface that relies on [libsodium](https://pecl.php.net/package/libsodium)
 for all of its underlying cryptography operations.
@@ -15,10 +20,47 @@ without making your source code available under a GPL-compatible license.
 
 ## Using Halite in Your Applications
 
-1. [Install Libsodium and the PHP Extension](https://paragonie.com/book/pecl-libsodium/read/00-intro.md#installing-libsodium)
-2. `composer require paragonie/halite`
+### Step 1: Installing libsodium
 
-**Halite Version 2 requires PHP 7.0.0 or newer!**
+Before you can use Halite, you must choose a version that fits the requirements 
+of your project. The differences between the requirements for the available 
+versions of Halite are briefly highlighted below.
+
+|           | PHP   | libsodium | PECL libsodium |
+|-----------|-------|-----------|----------------|
+| Halite 2+ | 7.0.0 | 1.0.9     | 1.0.6          |
+| Halite 1  | 5.6.0 | 1.0.6     | 1.0.2          |
+
+If you plan to use Halite 2+, you might need to
+[compile libsodium from source](https://paragonie.com/book/pecl-libsodium/read/00-intro.md#installing-libsodium-source)
+since your distribution probably won't have the necessary version quite yet.
+
+If you plan to use Halite 1, or your distribution has the necessary version already,
+then you should be able to
+[install a precompiled libsodium](https://paragonie.com/book/pecl-libsodium/read/00-intro.md#installing-libsodium)
+package.
+
+### Step 2: Installing the PECL libsodium extension
+
+**Important Note**: It is important that this step is repeated every time that a
+different version of libsodium is installed. The resulting PECL libsodium extension
+is version dependent of the currently installed libsodium.
+
+Installation instructions for the PECL libsodium extension can be found in the
+[PECL libsodium book](https://paragonie.com/book/pecl-libsodium/read/00-intro.md#installing-extension)
+on the Paragon Initiative Enterprises website.
+
+### Step 3: Use Composer to install Halite
+
+The last step required to use Halite is to install it using Composer.
+
+For the latest version of Halite:
+
+    composer require paragonie/halite
+
+Or for older versions of Halite, specify the version number:
+
+    composer require paragonie/halite:^v1
 
 ## Using Halite in Your Project
 
@@ -42,3 +84,68 @@ Check out the [documentation](doc). The basic Halite API is designed for simplic
     * Asymmetric
        * `Asymmetric\Crypto::sign`(`string`, [`SignatureSecretKey`](doc/Classes/Asymmetric/SignatureSecretKey.md), `bool?`): `string`
        * `Asymmetric\Crypto::verify`(`string`, [`SignaturePublicKey`](doc/Classes/Asymmetric/SignaturePublicKey.md), `string`, `bool?`): `bool`
+
+### Example: Encrypting and Decrypting a message
+
+First, generate and persist a key exactly once:
+
+```php
+<?php
+use ParagonIE\Halite\KeyFactory;
+
+$encKey = KeyFactory::generateEncryptionKey();
+KeyFactory::save($encKey, '/path/outside/webroot/encryption.key');
+```
+
+And then you can encrypt/decrypt messages like so:
+
+```php
+<?php
+use ParagonIE\Halite\KeyFactory;
+use ParagonIE\Halite\Symmetric\Crypto as Symmetric;
+
+$encryptionKey = KeyFactory::loadEncryptionKey('/path/outside/webroot/encryption.key');
+
+$message = 'This is a confidential message for your eyes only.';
+$ciphertext = Symmetric::encrypt($message, $encryptionKey);
+
+$decrypted = Symmetric::decrypt($ciphertext, $encryptionKey);
+
+var_dump($decrypted === $message); // bool(true)
+```
+
+This should produce something similar to:
+
+    314202017d893cb20eeab4ef51f6861d55a60797c6de0453f11e464ce210091b914b1c40470869d3d390986eeebe2d34e393efe986fc52de7464f30d8d38df5c6b629c019c454a2eec03ca618f9e2ba34f20c81614d63988f0f845911cafbeee7e79893e1f7c33e298da3b3474ac3ea9181298a2ce7e468914c329b35f50ac32b01136dc87e7f7881d31909227273817ac01c3b8f19dc6db881ad962d5b3e4c95d61494747028114f15a2e718c19
+
+### Example: Generating a key from a password
+
+```php
+<?php
+use ParagonIE\Halite\KeyFactory;
+use ParagonIE\Halite\Symmetric\Crypto as Symmetric;
+
+$passwd = 'correct horse battery staple';
+// Use random_bytes(16); to generate the salt:
+$salt = "\xdd\x7b\x1e\x38\x75\x9f\x72\x86\x0a\xe9\xc8\x58\xf6\x16\x0d\x3b";
+
+$encryptionKey = KeyFactory::deriveEncryptionKey($passwd, $salt);
+```
+
+A key derived from a password can be used in place of one randomly generated.
+
+### Example: Encrypting a large file on a system with low memory
+
+Halite includes a file cryptography class that utilizes a streaming API to
+allow large files (e.g. gigabytes) be encrypted on a system with very little
+available memory (i.e. less than 8 MB).
+
+```php
+<?php
+use ParagonIE\Halite\File;
+use ParagonIE\Halite\KeyFactory;
+
+$encryptionKey = KeyFactory::loadEncryptionKey('/path/outside/webroot/encryption.key');
+
+File::encrypt('input.txt', 'output.txt', $encryptionKey);
+```

--- a/src/Asymmetric/Crypto.php
+++ b/src/Asymmetric/Crypto.php
@@ -121,7 +121,7 @@ abstract class Crypto
                 'Argument 2: Expected an instance of EncryptionPublicKey'
             );
         }
-        if (!function_exists('\\Sodium\\crypto_box_seal')) {
+        if (!\is_callable('\\Sodium\\crypto_box_seal')) {
             throw new CryptoException\CannotPerformOperation(
                 'crypto_box_seal is not available'
             );

--- a/src/Halite.php
+++ b/src/Halite.php
@@ -40,7 +40,7 @@ abstract class Halite
         }
 
         // Added in version 1.0.3 of the PHP extension
-        if (!\function_exists('\\Sodium\\crypto_pwhash_str')) {
+        if (!\is_callable('\\Sodium\\crypto_pwhash_str')) {
             if ($echo) {
                 echo 'Halite needs version 1.0.6 or higher of the PHP extension installed.', "\n";
             }

--- a/src/KeyFactory.php
+++ b/src/KeyFactory.php
@@ -364,7 +364,146 @@ abstract class KeyFactory
                 );
         }
     }
-    
+    /**
+     * Load a symmetric authentication key from a string
+     *
+     * @param string $keyData
+     * @return AuthenticationKey
+     *
+     * @throws Alerts\CannotPerformOperation
+     */
+    public static function importAuthenticationKey(string $keyData): AuthenticationKey
+    {
+        return new AuthenticationKey(
+            self::getKeyDataFromString(
+                \Sodium\hex2bin($keyData)
+            )
+        );
+    }
+
+    /**
+     * Load a symmetric encryption key from a string
+     *
+     * @param string $keyData
+     * @return EncryptionKey
+     *
+     * @throws Alerts\CannotPerformOperation
+     */
+    public static function importEncryptionKey(string $keyData): EncryptionKey
+    {
+        return new EncryptionKey(
+            self::getKeyDataFromString(
+                \Sodium\hex2bin($keyData)
+            )
+        );
+    }
+
+    /**
+     * Load, specifically, an encryption public key from a string
+     *
+     * @param string $keyData
+     * @return EncryptionPublicKey
+     *
+     * @throws Alerts\CannotPerformOperation
+     */
+    public static function importEncryptionPublicKey(string $keyData): EncryptionPublicKey
+    {
+        return new EncryptionPublicKey(
+            self::getKeyDataFromString(
+                \Sodium\hex2bin($keyData)
+            )
+        );
+    }
+
+    /**
+     * Load, specifically, an encryption secret key from a string
+     *
+     * @param string $keyData
+     * @return EncryptionSecretKey
+     *
+     * @throws Alerts\CannotPerformOperation
+     */
+    public static function importEncryptionSecretKey(string $keyData): EncryptionSecretKey
+    {
+        return new EncryptionSecretKey(
+            self::getKeyDataFromString(
+                \Sodium\hex2bin($keyData)
+            )
+        );
+    }
+
+    /**
+     * Load, specifically, a signature public key from a string
+     *
+     * @param string $keyData
+     * @return SignaturePublicKey
+     *
+     * @throws Alerts\CannotPerformOperation
+     */
+    public static function importSignaturePublicKey(string $keyData): SignaturePublicKey
+    {
+        return new SignaturePublicKey(
+            self::getKeyDataFromString(
+                \Sodium\hex2bin($keyData)
+            )
+        );
+    }
+
+    /**
+     * Load, specifically, a signature secret key from a string
+     *
+     * @param string $keyData
+     * @return SignatureSecretKey
+     *
+     * @throws Alerts\CannotPerformOperation
+     */
+    public static function importSignatureSecretKey(string $keyData): SignatureSecretKey
+    {
+        return new SignatureSecretKey(
+            self::getKeyDataFromString(
+                \Sodium\hex2bin($keyData)
+            )
+        );
+    }
+
+    /**
+     * Load an asymmetric encryption key pair from a string
+     *
+     * @param string $keyData
+     * @return EncryptionKeyPair
+     *
+     * @throws Alerts\CannotPerformOperation
+     */
+    public static function importEncryptionKeyPair(string $keyData): EncryptionKeyPair
+    {
+        return new EncryptionKeyPair(
+            new EncryptionSecretKey(
+                self::getKeyDataFromString(
+                    \Sodium\hex2bin($keyData)
+                )
+            )
+        );
+    }
+
+    /**
+     * Load an asymmetric signature key pair from a string
+     *
+     * @param string $keyData
+     * @return SignatureKeyPair
+     *
+     * @throws Alerts\CannotPerformOperation
+     */
+    public static function importSignatureKeyPair(string $keyData): SignatureKeyPair
+    {
+        return new SignatureKeyPair(
+            new SignatureSecretKey(
+                self::getKeyDataFromString(
+                    \Sodium\hex2bin($keyData)
+                )
+            )
+        );
+    }
+
     /**
      * Load a symmetric authentication key from a file
      * 
@@ -527,6 +666,33 @@ abstract class KeyFactory
                 self::loadKeyFile($filePath)
             )
         );
+    }
+
+    /**
+     * Export a cryptography key to a string (with a checksum)
+     *
+     * @param $key
+     * @return string
+     * @throws \TypeError
+     */
+    public static function export($key): string
+    {
+        if ($key instanceof KeyPair) {
+            return self::export(
+                $key->getSecretKey()
+            );
+        }
+        if ($key instanceof Key) {
+            return \Sodium\bin2hex(
+                Halite::HALITE_VERSION_KEYS . $key->getRawKeyMaterial() .
+                \Sodium\crypto_generichash(
+                    Halite::HALITE_VERSION_KEYS . $key->getRawKeyMaterial(),
+                    '',
+                    \Sodium\CRYPTO_GENERICHASH_BYTES_MAX
+                )
+            );
+        }
+        throw new \TypeError('Expected a Key.');
     }
     
     /**

--- a/src/Symmetric/EncryptionKey.php
+++ b/src/Symmetric/EncryptionKey.php
@@ -17,7 +17,9 @@ final class EncryptionKey extends SecretKey
      */
     public function __construct(string $keyMaterial = '')
     {
-        if (CryptoUtil::safeStrlen($keyMaterial) !== \Sodium\CRYPTO_STREAM_KEYBYTES) {
+        // allow long keys for symmetric encryption 
+        // (temporary; for compatibility with legacy keys)
+        if (CryptoUtil::safeStrlen($keyMaterial) < \Sodium\CRYPTO_STREAM_KEYBYTES) {
             throw new InvalidKey(
                 'Encryption key must be CRYPTO_STREAM_KEYBYTES bytes long'
             );

--- a/src/Util.php
+++ b/src/Util.php
@@ -181,7 +181,7 @@ abstract class Util
     {
         static $exists = null;
         if ($exists === null) {
-            $exists = \function_exists('mb_strlen');
+            $exists = \is_callable('mb_strlen');
         }
 
         if ($exists) {
@@ -222,7 +222,7 @@ abstract class Util
     ): string {
         static $exists = null;
         if ($exists === null) {
-            $exists = \function_exists('mb_substr');
+            $exists = \is_callable('mb_substr');
         }
         if ($exists) {
             // mb_substr($str, 0, NULL, '8bit') returns an empty string on PHP

--- a/test/unit/KeyTest.php
+++ b/test/unit/KeyTest.php
@@ -235,6 +235,13 @@ class KeyTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(
             \hash_equals($enc_public->getRawKeyMaterial(), $load_public->getRawKeyMaterial())
         );
+        $encoded = KeyFactory::export($enc_secret);
+        $imported = KeyFactory::importEncryptionSecretKey($encoded);
+
+        $this->assertSame(
+            $enc_secret->getRawKeyMaterial(),
+            $imported->getRawKeyMaterial()
+        );
         
         \unlink($file_secret);
         \unlink($file_public);
@@ -265,6 +272,14 @@ class KeyTest extends PHPUnit_Framework_TestCase
         );
         $this->assertTrue(
             \hash_equals($sign_public->getRawKeyMaterial(), $load_public->getRawKeyMaterial())
+        );
+
+        $encoded = KeyFactory::export($sign_secret);
+        $imported = KeyFactory::importSignatureSecretKey($encoded);
+
+        $this->assertSame(
+            $sign_secret->getRawKeyMaterial(),
+            $imported->getRawKeyMaterial()
         );
         
         \unlink($file_secret);

--- a/test/unit/PasswordTest.php
+++ b/test/unit/PasswordTest.php
@@ -27,6 +27,22 @@ class PasswordTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testRehash()
+    {
+        $key = new EncryptionKey(\str_repeat('A', 32));
+        $legacyHash = '3142010064c0c42347b248372d9605621bd6e56e6ace8d2c6f6a3cf3d1a37a40' .
+            '3f031b5be025f00763a92ffb47281065419663e972b1a8faa08ae34bd9fdb35b2ca7727f41' .
+            'ca8edc75293d8f3bf12604ff4188d71473b605d48d1e378388465c6e4c733cae5f89802ebb' .
+            '79ec6532b430a4799e545956113f116fa705e3ed2d7b17bb6dbf435f36a0f50dcb541adb82' .
+            'a83f6d01ae66b2f4d46540161ba6cc37dbd0e870aed8334cb71f8162a9e7e7974396bdb1bc' .
+            '4da5099423820b870e39a3ffe5';
+
+        $this->assertTrue(Password::needsRehash($legacyHash, $key));
+
+        $hash = Password::hash('test password', $key);
+        $this->assertFalse(Password::needsRehash($hash, $key));
+    }
+
     public function testLegacy()
     {
         $key = new EncryptionKey(\str_repeat('A', 32));


### PR DESCRIPTION
makes legacy nocworx keys compatible with this version of halite.
this is an intermediate upgrade to allow us to move to php 7.2.