### PR TITLE
Accept Long Keys for Symmetric Crypto

### DIFF
--- a/src/Symmetric/EncryptionKey.php
+++ b/src/Symmetric/EncryptionKey.php
@@ -17,7 +17,9 @@ final class EncryptionKey extends SecretKey
      */
     public function __construct(string $keyMaterial = '')
     {
-        if (CryptoUtil::safeStrlen($keyMaterial) !== \Sodium\CRYPTO_STREAM_KEYBYTES) {
+        // allow long keys for symmetric encryption 
+        // (temporary; for compatibility with legacy keys)
+        if (CryptoUtil::safeStrlen($keyMaterial) < \Sodium\CRYPTO_STREAM_KEYBYTES) {
             throw new InvalidKey(
                 'Encryption key must be CRYPTO_STREAM_KEYBYTES bytes long'
             );


### PR DESCRIPTION
makes legacy nocworx keys compatible with halite version 2.x.

this is an intermediate upgrade to allow us to move to php 7.2. we need a new tag for this once it's merged (suggest `v2.2.1`) so lib can require it.